### PR TITLE
replaced for of loops with classic ones

### DIFF
--- a/lib/quality-menu.js
+++ b/lib/quality-menu.js
@@ -8,7 +8,8 @@ class QualityMenu extends VjsMenu {
     component.on('click', () => {
       let children = this.children();
 
-      for (var child of children) {
+      for (var i=0; i < children.length; i++) {
+        var child = children[i];
         if (component !== child) {
           child.selected(false);
         }

--- a/lib/quality-picker-button.js
+++ b/lib/quality-picker-button.js
@@ -9,7 +9,8 @@ class QualityPickerButton extends VjsButton {
     var menu = new QualityMenu(this.player, this.options_);
     var menuItem;
     var options;
-    for (var quality of this.options_.qualityList) {
+    for (var i=0; i < this.options_.qualityList.length; i++) {
+      var quality = this.options_.qualityList[i];
       var {qualitySwitchCallback, trackType} = this.options_;
       options = Object.assign({qualitySwitchCallback, trackType}, quality, { selectable: true });
 

--- a/lib/vjs-quality-picker.js
+++ b/lib/vjs-quality-picker.js
@@ -18,8 +18,8 @@ function qualityPickerPlugin(options) {
         var fullscreenToggle = player.controlBar.getChild('fullscreenToggle');
         player.controlBar.removeChild(fullscreenToggle);
 
-        for (var track of SUPPORTED_TRACKS) {
-
+        for (var i=0; i < SUPPORTED_TRACKS.length; i++) {
+            var track = SUPPORTED_TRACKS[i];
             var name = track + "PickerButton";
             var qualityPickerButton = player.controlBar.getChild(name);
             if (qualityPickerButton) {


### PR DESCRIPTION
Replaced ES6 `for..of loops` by classical `for` loop. It should solve this issue https://github.com/streamroot/videojs5-hlsjs-source-handler/issues/12

@AxelDelmas could you check this PR please?