### PR TITLE
Added list of supported source handlers to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,7 @@ selected    | Boolean | Should be true for ONE quality ONLY: the one that is cur
         }
     }
 ```
+
+## List of supported video.js plugins & source handlers
+
+* [videojs5-hlsjs-source-handler](https://github.com/streamroot/videojs5-hlsjs-source-handler) -- adds HLS playback support to video.js 5.0+ using Dailymotion's hls.js library.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/128218915

I decided that it's better to list supported source handlers, either than saying, that it doesn't support `videojs-dashjs-source-handler`. What do you think?