### PR TITLE
Using Video.js registerPlugin() if available (for version 6)

### DIFF
--- a/lib/vjs-quality-picker.js
+++ b/lib/vjs-quality-picker.js
@@ -44,4 +44,6 @@ function qualityPickerPlugin() {
     }
 }
 
-videojs.plugin('qualityPickerPlugin', qualityPickerPlugin);
+var registerPlugin = videojs.registerPlugin || videojs.plugin;
+
+registerPlugin('qualityPickerPlugin', qualityPickerPlugin);


### PR DESCRIPTION
This change follows the recommendation of Video.js 6 Migration Guide (https://github.com/videojs/video.js/wiki/Video.js-6-Migration-Guide#videojsplugin) in order to use the new registerPlugin() method instead of the deprecated method plugin(), only if the new method is available (so it is still compatible with older versions).